### PR TITLE
fix: account set up logic fix

### DIFF
--- a/py/gaarf/cli/gaarf.py
+++ b/py/gaarf/cli/gaarf.py
@@ -82,14 +82,15 @@ def main():
         google_ads_config_dict = yaml.safe_load(f)
 
     config = GaarfConfigBuilder(args).build()
-    if account := main_args.customer_id:
-        config.account = account
-    elif mcc := google_ads_config_dict.get("login_customer_id"):
-        config.account = str(mcc)
-    else:
-        raise ValueError(
-            "No account found, please specify via --account CLI flag"
-            "or add as login_customer_id in google-ads.yaml")
+    if not config.account:
+        if account := main_args.customer_id:
+            config.account = account
+        elif mcc := google_ads_config_dict.get("login_customer_id"):
+            config.account = str(mcc)
+        else:
+            raise ValueError(
+                "No account found, please specify via --account CLI flag"
+                "or add as login_customer_id in google-ads.yaml")
     logger.debug("config: %s", config)
 
     if main_args.save_config and not main_args.gaarf_config:

--- a/py/gaarf/cli/gaarf.py
+++ b/py/gaarf/cli/gaarf.py
@@ -82,10 +82,10 @@ def main():
         google_ads_config_dict = yaml.safe_load(f)
 
     config = GaarfConfigBuilder(args).build()
+    if account := main_args.customer_id:
+        config.account = account
     if not config.account:
-        if account := main_args.customer_id:
-            config.account = account
-        elif mcc := google_ads_config_dict.get("login_customer_id"):
+        if mcc := google_ads_config_dict.get("login_customer_id")):
             config.account = str(mcc)
         else:
             raise ValueError(


### PR DESCRIPTION
Fix for logic of account set up.

Bug:
If you have account in config file, it would have been overwritten by command line arg. And if there's no command line arg for account it would have been overwritten by login_customer_id in google-ads.yaml.

Fix:
Added condition to overwrite account only if it wasn't set up in config file.